### PR TITLE
Modify webhook name to include user ID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ client.on("messageCreate", async (msg) => {
   const translatedText = await translate(msg.content, { from: channelCodeFromName, to: config.mirror.locale });
   await client.executeWebhook(channelWebhook.id, channelWebhook.token, {
     content: translatedText + attachments,
-    username: `${msg.author.username}#${msg.author.discriminator} (${channelCodeFromName} #${msg.channel.name})`,
+    username: `${msg.author.username} (${msg.author.id}) [${channelCodeFromName} #${msg.channel.name}]`,
     avatarURL: msg.author.avatarURL,
   });
 });


### PR DESCRIPTION
Very convenient for getting someone's user ID without going to the non-mirror channel and right clicking the user.