### PR TITLE
Misc Changes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ export const config = rc("translatebot", {
   status: "for translations",
   blacklist_roles: [],
   bot_prefixes: [],
-  channel_format: "support-(?<code>[a-z]+)",
+  channel_format: "support-(?<code>[a-z]{2}(-[a-z]{2})?)",
   mirror: {
     locale: "en",
   },

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ client.on("messageCreate", async (msg) => {
     return;
   }
 
-  const attachments = msg.attachments[0] ? ' ' + msg.attachments.map((attachment) => attachment.url).join(", ") : ""; // prettier-ignore
+  const attachments = msg.attachments[0] ? ' ' + msg.attachments.map((attachment) => attachment.url).join(" ") : ""; // prettier-ignore
   if (msg.channel.id === config.mirror.channel_id) {
     const parts = msg.content.split(" ");
     const channelCode = parts.shift();


### PR DESCRIPTION
Makes language code only allowed to be `ab-xy`, so for example en-us, en-gb, fr

removes the `, ` between attachment links that was preventing them from embeding